### PR TITLE
Add linker flag "-lz"

### DIFF
--- a/extra/hooks/xcode-project-patches.js
+++ b/extra/hooks/xcode-project-patches.js
@@ -39,6 +39,36 @@ function nonComments(obj) {
   return newObj;
 }
 
+if (!Array.prototype.includes) {
+  Array.prototype.includes = function(searchElement /*, fromIndex*/ ) {
+    var O = Object(this);
+    var len = parseInt(O.length, 10) || 0;
+    if (len === 0) {
+      return false;
+    }
+    var n = parseInt(arguments[1], 10) || 0;
+    var k;
+    if (n >= 0) {
+      k = n;
+    } else {
+      k = len + n;
+      if (k < 0) {
+        k = 0;
+      }
+    }
+    var currentElement;
+    while (k < len) {
+      currentElement = O[k];
+      if (searchElement === currentElement ||
+        (searchElement !== searchElement && currentElement !== currentElement)) { // NaN !== NaN
+        return true;
+      }
+      k++;
+    }
+    return false;
+  };
+}
+
 // Starting here
 
 module.exports = function(context) {

--- a/extra/hooks/xcode-project-patches.js
+++ b/extra/hooks/xcode-project-patches.js
@@ -39,6 +39,8 @@ function nonComments(obj) {
   return newObj;
 }
 
+// Array.includes() polyfill
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes
 if (!Array.prototype.includes) {
   Array.prototype.includes = function(searchElement /*, fromIndex*/ ) {
     var O = Object(this);
@@ -99,7 +101,7 @@ module.exports = function(context) {
   xcodeProject = xcode.project(xcodeProjectPath);
 
   // Showing info about the tasks to do
-  debug('fixing issues in the generated project files:');
+  debug('adding linker flag "-lz":');
 
   // Massaging the files
 
@@ -114,18 +116,14 @@ module.exports = function(context) {
     buildSettings = configurations[config].buildSettings;
     var linkerFlag = '"-lz"';
     var existingFlags = buildSettings.OTHER_LDFLAGS;
-    if (!buildSettings.OTHER_LDFLAGS.includes(linkerFlag)) {
-      buildSettings.OTHER_LDFLAGS.push(linkerFlag);
+    if (!existingFlags.includes(linkerFlag)) {
+      existingFlags.push(linkerFlag);
     }
-    console.log('--- OTHER_LDFLAGS is:');
-    console.dir(buildSettings.OTHER_LDFLAGS);
-    console.log('--- existingFlags is:');
-    console.dir(existingFlags);
   });
 
   // Writing the file again
-  // fs.writeFileSync(xcodeProjectPath, xcodeProject.writeSync(), 'utf-8');
-  // debug('file correctly fixed: ' + xcodeProjectPath);
+  fs.writeFileSync(xcodeProjectPath, xcodeProject.writeSync(), 'utf-8');
+  debug('file correctly fixed: ' + xcodeProjectPath);
 };
 
 

--- a/extra/hooks/xcode-project-patches.js
+++ b/extra/hooks/xcode-project-patches.js
@@ -39,7 +39,6 @@ function nonComments(obj) {
   return newObj;
 }
 
-
 // Starting here
 
 module.exports = function(context) {
@@ -83,10 +82,15 @@ module.exports = function(context) {
   // Adding or changing the parameters we need
   Object.keys(configurations).forEach(function(config) {
     buildSettings = configurations[config].buildSettings;
-    // buildSettings.LD_RUNPATH_SEARCH_PATHS = RUNPATH_SEARCH_PATHS_XCODE;
-    // buildSettings.IPHONEOS_DEPLOYMENT_TARGET = BUILD_VERSION_XCODE;
+    var linkerFlag = '"-lz"';
+    var existingFlags = buildSettings.OTHER_LDFLAGS;
+    if (!buildSettings.OTHER_LDFLAGS.includes(linkerFlag)) {
+      buildSettings.OTHER_LDFLAGS.push(linkerFlag);
+    }
     console.log('--- OTHER_LDFLAGS is:');
     console.dir(buildSettings.OTHER_LDFLAGS);
+    console.log('--- existingFlags is:');
+    console.dir(existingFlags);
   });
 
   // Writing the file again
@@ -96,10 +100,10 @@ module.exports = function(context) {
 
 
 function debug(msg) {
-  console.log('iosrtc-swift-support.js [INFO] ' + msg);
+  console.log('cordova-plugin-digits [INFO] ' + msg);
 }
 
 
 function debugerror(msg) {
-  console.error('iosrtc-swift-support.js [ERROR] ' + msg);
+  console.error('cordova-plugin-digits [ERROR] ' + msg);
 }

--- a/extra/hooks/xcode-project-patches.js
+++ b/extra/hooks/xcode-project-patches.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+'use strict';
+
+// This hook automates this:
+// https://github.com/eface2face/cordova-plugin-iosrtc/blob/master/docs/Building.md
+
+var
+  fs = require("fs"),
+  path = require("path"),
+
+  COMMENT_KEY = /_comment$/;
+
+
+// Helpers
+
+// Returns the project name
+function getProjectName(protoPath) {
+  var
+    cordovaConfigPath = path.join(protoPath, 'config.xml'),
+    content = fs.readFileSync(cordovaConfigPath, 'utf-8');
+
+  return /<name>([\s\S]*)<\/name>/mi.exec(content)[1].trim();
+}
+
+// Drops the comments
+function nonComments(obj) {
+  var
+    keys = Object.keys(obj),
+    newObj = {},
+    i = 0;
+
+  for (i; i < keys.length; i += 1) {
+    if (!COMMENT_KEY.test(keys[i])) {
+      newObj[keys[i]] = obj[keys[i]];
+    }
+  }
+
+  return newObj;
+}
+
+
+// Starting here
+
+module.exports = function(context) {
+  var
+    xcode = context.requireCordovaModule('xcode'),
+    projectRoot = context.opts.projectRoot,
+    projectName = getProjectName(projectRoot),
+    xcconfigPath = path.join(projectRoot, '/platforms/ios/cordova/build.xcconfig'),
+    xcodeProjectName = projectName + '.xcodeproj',
+    xcodeProjectPath = path.join(projectRoot, 'platforms', 'ios', xcodeProjectName, 'project.pbxproj'),
+    xcodeProject;
+
+  // Checking if the project files are in the right place
+  if (!fs.existsSync(xcodeProjectPath)) {
+    debugerror('an error occurred searching the project file at: "' + xcodeProjectPath + '"');
+
+    return;
+  }
+  debug('".pbxproj" project file found: ' + xcodeProjectPath);
+
+  if (!fs.existsSync(xcconfigPath)) {
+    debugerror('an error occurred searching the project file at: "' + xcconfigPath + '"');
+
+    return;
+  }
+  debug('".xcconfig" project file found: ' + xcconfigPath);
+
+  xcodeProject = xcode.project(xcodeProjectPath);
+
+  // Showing info about the tasks to do
+  debug('fixing issues in the generated project files:');
+
+  // Massaging the files
+
+  // "project.pbxproj"
+  // Parsing it
+  xcodeProject.parseSync();
+  var configurations, buildSettings;
+
+  configurations = nonComments(xcodeProject.pbxXCBuildConfigurationSection());
+  // Adding or changing the parameters we need
+  Object.keys(configurations).forEach(function(config) {
+    buildSettings = configurations[config].buildSettings;
+    // buildSettings.LD_RUNPATH_SEARCH_PATHS = RUNPATH_SEARCH_PATHS_XCODE;
+    // buildSettings.IPHONEOS_DEPLOYMENT_TARGET = BUILD_VERSION_XCODE;
+    console.log('--- OTHER_LDFLAGS is:');
+    console.dir(buildSettings.OTHER_LDFLAGS);
+  });
+
+  // Writing the file again
+  // fs.writeFileSync(xcodeProjectPath, xcodeProject.writeSync(), 'utf-8');
+  // debug('file correctly fixed: ' + xcodeProjectPath);
+};
+
+
+function debug(msg) {
+  console.log('iosrtc-swift-support.js [INFO] ' + msg);
+}
+
+
+function debugerror(msg) {
+  console.error('iosrtc-swift-support.js [ERROR] ' + msg);
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -52,6 +52,7 @@
   </platform>
 
   <platform name="ios">
+    <hook type="after_prepare" src="extra/hooks/xcode-project-patches.js" />
     <config-file target="config.xml" parent="/*">
       <feature name="Digits">
         <param name="ios-package" value="CDVDigits" />


### PR DESCRIPTION
With the current version of your fork, the build on iOS failed. This was due to a missing linker flag. I've wrote a hook script that adds this flag automatically. It works for me, I am using the plugin in combination with Meteor.js. Not sure if it works with plain vanilla Cordova or other frameworks like Ionic. But it should. Feel free to add it to your fork as well.